### PR TITLE
add unitystart.bash and docker/kill.bash

### DIFF
--- a/docker/kill.bash
+++ b/docker/kill.bash
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+IMANGE_NAME=` cat docker/run/image_name.txt`
+docker ps | grep "${IMANGE_NAME}" > /dev/null
+if [ $? -ne 0 ]
+then
+    echo "INFO: Not find hakoniwa-zumosim-run."
+    exit 1
+fi
+
+DOCKER_ID=`docker ps | grep "${IMANGE_NAME}" | awk '{print $1}'` 
+docker kill ${DOCKER_ID}

--- a/simstart.bash
+++ b/simstart.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 HAKO_UNITY_BIN_PATH="./ZumoApp"
 HAKO_UNITY_BIN=model.exe
-
+CURRENT_DIR=`pwd`
 
 if [ ! -d ${HAKO_UNITY_BIN_PATH} ]
 then
@@ -25,7 +25,7 @@ function signal_handler()
 }
 function kill_process()
 {
-    echo "trapped"
+    echo "INFO: STOPPING Simulation"
     if [ -z "$HAKO_RUN_PID" ]
     then
         exit 0
@@ -41,7 +41,6 @@ function kill_process()
         echo "KILLING: docker $DOCKER_ID"
         docker kill ${DOCKER_ID}
     fi
-    
     echo "KILLING: HAKO_RUN $HAKO_RUN_PID"
     kill -9 "$HAKO_RUN_PID" || echo "Failed to kill HAKO_RUN"
 
@@ -54,7 +53,7 @@ function kill_process()
         fi
         sleep 1
     done
-
+    echo "INFO: STOP DONE"
     exit 0
 }
 trap signal_handler SIGINT

--- a/unitystart.bash
+++ b/unitystart.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+HAKO_UNITY_BIN_PATH="./ZumoApp"
+HAKO_UNITY_BIN=model.exe
+
+
+IMANGE_NAME=` cat docker/run/image_name.txt`
+docker ps | grep "${IMANGE_NAME}" > /dev/null
+if [ $? -ne 0 ]
+then
+    echo "ERROR: Cannot find hakoniwa-zumosim-run."
+    echo "Please open a new terminal and execute the following command:"
+    echo "bash docker/run.bash"
+    exit 1
+fi
+
+if [ ! -d ${HAKO_UNITY_BIN_PATH} ]
+then
+    echo "ERROR: can not found ${HAKO_UNITY_BIN_PATH}"
+    exit 1
+fi
+bash utils/set_core_config.bash ${HAKO_UNITY_BIN_PATH}
+if [ $? -ne 0 ]
+then
+    exit 1
+fi
+
+echo "INFO: Unity start"
+
+
+
+
+cd ${HAKO_UNITY_BIN_PATH}
+./${HAKO_UNITY_BIN} &
+HAKO_UNITY_PID=$!
+
+sleep 1
+
+while true; do
+    echo "Press ENTER to stop..."
+    read input
+    if [ -z "$input" ]; then
+        kill_process
+        break
+    fi
+done
+

--- a/utils/set_core_config.bash
+++ b/utils/set_core_config.bash
@@ -22,6 +22,12 @@ then
     exit 1
 fi
 
+if [ ! -f third-party/mustache/mo ]
+then
+    echo "ERROR: can not find third-party/mustache/mo"
+    exit 1
+fi
+
 bash third-party/mustache/mo utils/template/core_config_json.mo > ${UNITY_BIN_PATH}/core_config.json
 
 exit 0


### PR DESCRIPTION
以下を追加しました。

* unitystart.bash
  * unity を単独起動するためのツール
* docker/kill.bash
  * docker コンテナをkill するためのメンテツール

ただ、上記コマンドをユーザに叩いてもらうには、難易度が高めになります。
そのため、ユーザフレンドリーな `simstart.bash` を使ってもらうのがやはりベターだと思います。

シミュレーション開始方法：

```
 bash simstart.bash
```

シミュレーション停止方法：

同じ端末上で、Enterキーを押下してください。

あと、Unityアプリですが、Windows Defender に表示されない問題、こちらでも再現しました。

この状態になると、UDP通信がそもそも実現できなくなってしまうため、
以下の手順で実施することで問題を解消できました。

1. ZumoAppを全削除
2. ZumoApp.zipを再解凍
3. Windows 再起動
4. model.exe を手動起動し、Windowsの実行許可を得てから、強制停止（×ボタン押下）
5. bash simstart.bash 実行すると、Windowsアクセス許可が聞かれるので許可する
